### PR TITLE
Oz/allow-custom-authentication-headers

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -112,7 +112,7 @@ func (p *openApiPlugin) ExecuteAction(actionContext *plugin.ActionContext, reque
 		return res, nil
 	}
 
-	result, err := executeRequestWithCredentials(connection, openApiRequest, p.headerValuePrefixes, p.headerAlias, p.callbacks.setCustomAuthHeaders, request.Timeout)
+	result, err := executeRequestWithCredentials(connection, openApiRequest, p.headerValuePrefixes, p.headerAlias, p.callbacks.SetCustomAuthHeaders, request.Timeout)
 
 	res.Result = result.Body
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -64,7 +64,7 @@ type parsedOpenApi struct {
 type Callbacks struct {
 	TestCredentialsFunc  func(*plugin.ActionContext) (*plugin.CredentialsValidationResponse, error)
 	ValidateResponse     func(Result) (bool, []byte)
-	setCustomAuthHeaders SetCustomAuthHeaders
+	SetCustomAuthHeaders SetCustomAuthHeaders
 }
 
 func (p *openApiPlugin) Describe() plugin.Description {

--- a/plugin/request_test.go
+++ b/plugin/request_test.go
@@ -50,7 +50,7 @@ func (suite *PluginTestSuite) TestSetAuthenticationHeaders() {
 		suite.T().Run("test parseActionRequest(): "+tt.name, func(t *testing.T) {
 			connection, err := ctx.GetCredentials("test")
 			require.Nil(t, err)
-			err = setAuthenticationHeaders(connection, tt.args.httpreq, nil, nil, nil)
+			err = setAuthenticationHeaders(connection, tt.args.httpreq, nil, nil)
 			require.Nil(t, err)
 			assert.Contains(t, tt.args.httpreq.Header, "Authorization")
 			splitSlice := strings.Split(tt.args.httpreq.Header["Authorization"][0], " ")


### PR DESCRIPTION
I replaced the GetTokenFromCredentials function with SetCustomAuthHeaders - 
Now any plugin that requires custom authentication headers, will just be able to create them by itself.
This will break GCP and Azure integrations.